### PR TITLE
chore: bump version to 0.8.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "kobject"
-version = "0.7.5"
+version = "0.8.0"
 description = "Know your object is a attribute type checker"
 authors = [{ name = "Marco Sievers de Almeida Ximit Gaia", email = "im.ximit@gmail.com" }]
 requires-python = ">=3.10,<4"

--- a/uv.lock
+++ b/uv.lock
@@ -459,7 +459,7 @@ wheels = [
 
 [[package]]
 name = "kobject"
-version = "0.7.5"
+version = "0.8.0"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
Version bump `0.7.5` → `0.8.0` for the 0.8 release (features landed in #4).

The bump commit was pushed to the feature branch after #4 was already merged, so it never reached `main`. This PR lands it cleanly.

After merge, tag `v0.8.0` will be pushed to trigger the PyPI publish workflow.

## Highlights of 0.8.0
- `typing.Literal` support
- Tagged discriminated unions
- Generic models / `TypeVar` fields
- Optional `orjson` backend (`kobject[orjson]`)
- JSON Schema Draft 2020-12 + validation/serialization modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)